### PR TITLE
feat: Enhance sidebar data and update documentation

### DIFF
--- a/sidebar/Descricao.md
+++ b/sidebar/Descricao.md
@@ -4,11 +4,13 @@ Este arquivo JSON serve como a fonte de dados para a construção de um componen
 
 ## Estrutura Principal do Objeto
 
-O objeto JSON principal contém três chaves:
+O objeto JSON principal contém as seguintes chaves:
 
 -   `arraySidebar`: (Array) O contêiner principal para todos os grupos de navegação.
 -   `sideBarVerticalisExpanded`: (Boolean) Controla o estado de expansão da sidebar (se está expandida ou recolhida).
--   `sideBarVerticalSizeExpanded`: (Number) Define a largura da sidebar quando ela está no estado expandido.
+-   `sideBarVerticalSizeExpanded`: (Number) Define a largura da sidebar em pixels quando ela está no estado expandido.
+-   `sideBarVerticalSizeCollapsed`: (Number) Define a largura da sidebar em pixels quando ela está no estado recolhido.
+-   `typeSidebar`: (String) Define o tipo da sidebar (ex: "Vertical").
 
 ## Estrutura do `arraySidebar`
 
@@ -23,8 +25,9 @@ Este array contém múltiplos objetos, onde cada objeto representa um "grupo" de
 Cada objeto dentro deste array representa um item de navegação principal, que pode ou não ter subitens.
 
 -   **Objeto de Item**:
-    -   `idItem`: (Number) Um identificador numérico único para o item. A numeração é contínua através de todos os grupos.
-    -   `titleItem`: (String) O texto que será exibido para este item (ex: "item 1").
+-   `idItem`: (Number) Um identificador numérico único para o item.
+-   `titleItem`: (String) O texto que será exibido para este item (atualmente padronizado como "item").
+-   `icon`: (String) O nome de um ícone da biblioteca Phosphor Icons a ser exibido ao lado do título.
     -   `arraySubitem`: (Array) Contém os subitens de navegação associados a este item principal.
 
 ## Estrutura do `arraySubitem`
@@ -32,8 +35,9 @@ Cada objeto dentro deste array representa um item de navegação principal, que 
 Cada objeto neste array representa um subitem de navegação, que é o link final.
 
 -   **Objeto de Subitem**:
-    -   `idSubitem`: (Number) Um identificador numérico único para o subitem, geralmente no formato `[idItem].[index]` (ex: `1.1`).
-    -   `titleSubitem`: (String) O texto que será exibido para o subitem (ex: "textsubitem 1.1").
+-   `idSubitem`: (Number) Um identificador numérico único para o subitem, geralmente no formato `[idItem].[index]`.
+-   `titleSubitem`: (String) O texto que será exibido para o subitem (atualmente padronizado como "subitem").
+-   `icon`: (String) O nome de um ícone da biblioteca Phosphor Icons a ser exibido ao lado do título.
     -   `objectSubitem`: (Object) Um objeto que contém metadados e configurações para o comportamento do link do subitem.
         -   `type`: (String) Tipo de ação ou link.
         -   `pageid`: (String) Identificador da página de destino.

--- a/sidebar/sidebar.json
+++ b/sidebar/sidebar.json
@@ -5,57 +5,62 @@
       "arrayItem": [
         {
           "idItem": 1,
-          "titleItem": "item 1",
+          "titleItem": "item",
+          "icon": "function",
           "arraySubitem": [
-            {"idSubitem": 1.1, "titleSubitem": "textsubitem 1.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 1.2, "titleSubitem": "textsubitem 1.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 1.3, "titleSubitem": "textsubitem 1.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 1.4, "titleSubitem": "textsubitem 1.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 1.5, "titleSubitem": "textsubitem 1.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 1.1, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 1.2, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 1.3, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 1.4, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 1.5, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 2,
-          "titleItem": "item 2",
+          "titleItem": "item",
+          "icon": "airplane-landing",
           "arraySubitem": [
-            {"idSubitem": 2.1, "titleSubitem": "textsubitem 2.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 2.2, "titleSubitem": "textsubitem 2.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 2.3, "titleSubitem": "textsubitem 2.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 2.4, "titleSubitem": "textsubitem 2.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 2.5, "titleSubitem": "textsubitem 2.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 2.1, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 2.2, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 2.3, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 2.4, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 2.5, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 3,
-          "titleItem": "item 3",
+          "titleItem": "item",
+          "icon": "address-book",
           "arraySubitem": [
-            {"idSubitem": 3.1, "titleSubitem": "textsubitem 3.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 3.2, "titleSubitem": "textsubitem 3.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 3.3, "titleSubitem": "textsubitem 3.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 3.4, "titleSubitem": "textsubitem 3.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 3.5, "titleSubitem": "textsubitem 3.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 3.1, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 3.2, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 3.3, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 3.4, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 3.5, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 4,
-          "titleItem": "item 4",
+          "titleItem": "item",
+          "icon": "airplane-takeoff",
           "arraySubitem": [
-            {"idSubitem": 4.1, "titleSubitem": "textsubitem 4.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 4.2, "titleSubitem": "textsubitem 4.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 4.3, "titleSubitem": "textsubitem 4.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 4.4, "titleSubitem": "textsubitem 4.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 4.5, "titleSubitem": "textsubitem 4.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 4.1, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 4.2, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 4.3, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 4.4, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 4.5, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 5,
-          "titleItem": "item 5",
+          "titleItem": "item",
+          "icon": "air-traffic-control",
           "arraySubitem": [
-            {"idSubitem": 5.1, "titleSubitem": "textsubitem 5.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 5.2, "titleSubitem": "textsubitem 5.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 5.3, "titleSubitem": "textsubitem 5.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 5.4, "titleSubitem": "textsubitem 5.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 5.5, "titleSubitem": "textsubitem 5.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 5.1, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 5.2, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 5.3, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 5.4, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 5.5, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         }
       ]
@@ -65,57 +70,62 @@
       "arrayItem": [
         {
           "idItem": 6,
-          "titleItem": "item 6",
+          "titleItem": "item",
+          "icon": "airplane-tilt",
           "arraySubitem": [
-            {"idSubitem": 6.1, "titleSubitem": "textsubitem 6.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 6.2, "titleSubitem": "textsubitem 6.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 6.3, "titleSubitem": "textsubitem 6.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 6.4, "titleSubitem": "textsubitem 6.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 6.5, "titleSubitem": "textsubitem 6.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 6.1, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 6.2, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 6.3, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 6.4, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 6.5, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 7,
-          "titleItem": "item 7",
+          "titleItem": "item",
+          "icon": "buildings",
           "arraySubitem": [
-            {"idSubitem": 7.1, "titleSubitem": "textsubitem 7.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 7.2, "titleSubitem": "textsubitem 7.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 7.3, "titleSubitem": "textsubitem 7.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 7.4, "titleSubitem": "textsubitem 7.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 7.5, "titleSubitem": "textsubitem 7.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 7.1, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 7.2, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 7.3, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 7.4, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 7.5, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 8,
-          "titleItem": "item 8",
+          "titleItem": "item",
+          "icon": "airplay",
           "arraySubitem": [
-            {"idSubitem": 8.1, "titleSubitem": "textsubitem 8.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 8.2, "titleSubitem": "textsubitem 8.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 8.3, "titleSubitem": "textsubitem 8.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 8.4, "titleSubitem": "textsubitem 8.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 8.5, "titleSubitem": "textsubitem 8.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 8.1, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 8.2, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 8.3, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 8.4, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 8.5, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 9,
-          "titleItem": "item 9",
+          "titleItem": "item",
+          "icon": "airplane",
           "arraySubitem": [
-            {"idSubitem": 9.1, "titleSubitem": "textsubitem 9.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 9.2, "titleSubitem": "textsubitem 9.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 9.3, "titleSubitem": "textsubitem 9.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 9.4, "titleSubitem": "textsubitem 9.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 9.5, "titleSubitem": "textsubitem 9.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 9.1, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 9.2, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 9.3, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 9.4, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 9.5, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 10,
-          "titleItem": "item 10",
+          "titleItem": "item",
+          "icon": "youtube-logo",
           "arraySubitem": [
-            {"idSubitem": 10.1, "titleSubitem": "textsubitem 10.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 10.2, "titleSubitem": "textsubitem 10.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 10.3, "titleSubitem": "textsubitem 10.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 10.4, "titleSubitem": "textsubitem 10.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 10.5, "titleSubitem": "textsubitem 10.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 10.1, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 10.2, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 10.3, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 10.4, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 10.5, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         }
       ]
@@ -125,57 +135,62 @@
       "arrayItem": [
         {
           "idItem": 11,
-          "titleItem": "item 11",
+          "titleItem": "item",
+          "icon": "airplane-in-flight",
           "arraySubitem": [
-            {"idSubitem": 11.1, "titleSubitem": "textsubitem 11.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 11.2, "titleSubitem": "textsubitem 11.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 11.3, "titleSubitem": "textsubitem 11.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 11.4, "titleSubitem": "textsubitem 11.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 11.5, "titleSubitem": "textsubitem 11.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 11.1, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 11.2, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 11.3, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 11.4, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 11.5, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 12,
-          "titleItem": "item 12",
+          "titleItem": "item",
+          "icon": "function",
           "arraySubitem": [
-            {"idSubitem": 12.1, "titleSubitem": "textsubitem 12.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 12.2, "titleSubitem": "textsubitem 12.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 12.3, "titleSubitem": "textsubitem 12.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 12.4, "titleSubitem": "textsubitem 12.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 12.5, "titleSubitem": "textsubitem 12.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 12.1, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 12.2, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 12.3, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 12.4, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 12.5, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 13,
-          "titleItem": "item 13",
+          "titleItem": "item",
+          "icon": "airplane-landing",
           "arraySubitem": [
-            {"idSubitem": 13.1, "titleSubitem": "textsubitem 13.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 13.2, "titleSubitem": "textsubitem 13.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 13.3, "titleSubitem": "textsubitem 13.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 13.4, "titleSubitem": "textsubitem 13.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 13.5, "titleSubitem": "textsubitem 13.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 13.1, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 13.2, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 13.3, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 13.4, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 13.5, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 14,
-          "titleItem": "item 14",
+          "titleItem": "item",
+          "icon": "address-book",
           "arraySubitem": [
-            {"idSubitem": 14.1, "titleSubitem": "textsubitem 14.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 14.2, "titleSubitem": "textsubitem 14.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 14.3, "titleSubitem": "textsubitem 14.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 14.4, "titleSubitem": "textsubitem 14.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 14.5, "titleSubitem": "textsubitem 14.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 14.1, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 14.2, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 14.3, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 14.4, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 14.5, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 15,
-          "titleItem": "item 15",
+          "titleItem": "item",
+          "icon": "airplane-takeoff",
           "arraySubitem": [
-            {"idSubitem": 15.1, "titleSubitem": "textsubitem 15.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 15.2, "titleSubitem": "textsubitem 15.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 15.3, "titleSubitem": "textsubitem 15.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 15.4, "titleSubitem": "textsubitem 15.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 15.5, "titleSubitem": "textsubitem 15.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 15.1, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 15.2, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 15.3, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 15.4, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 15.5, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         }
       ]
@@ -185,57 +200,62 @@
       "arrayItem": [
         {
           "idItem": 16,
-          "titleItem": "item 16",
+          "titleItem": "item",
+          "icon": "air-traffic-control",
           "arraySubitem": [
-            {"idSubitem": 16.1, "titleSubitem": "textsubitem 16.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 16.2, "titleSubitem": "textsubitem 16.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 16.3, "titleSubitem": "textsubitem 16.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 16.4, "titleSubitem": "textsubitem 16.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 16.5, "titleSubitem": "textsubitem 16.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 16.1, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 16.2, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 16.3, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 16.4, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 16.5, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 17,
-          "titleItem": "item 17",
+          "titleItem": "item",
+          "icon": "airplane-tilt",
           "arraySubitem": [
-            {"idSubitem": 17.1, "titleSubitem": "textsubitem 17.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 17.2, "titleSubitem": "textsubitem 17.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 17.3, "titleSubitem": "textsubitem 17.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 17.4, "titleSubitem": "textsubitem 17.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 17.5, "titleSubitem": "textsubitem 17.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 17.1, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 17.2, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 17.3, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 17.4, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 17.5, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 18,
-          "titleItem": "item 18",
+          "titleItem": "item",
+          "icon": "buildings",
           "arraySubitem": [
-            {"idSubitem": 18.1, "titleSubitem": "textsubitem 18.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 18.2, "titleSubitem": "textsubitem 18.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 18.3, "titleSubitem": "textsubitem 18.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 18.4, "titleSubitem": "textsubitem 18.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 18.5, "titleSubitem": "textsubitem 18.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 18.1, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 18.2, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 18.3, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 18.4, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 18.5, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 19,
-          "titleItem": "item 19",
+          "titleItem": "item",
+          "icon": "airplay",
           "arraySubitem": [
-            {"idSubitem": 19.1, "titleSubitem": "textsubitem 19.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 19.2, "titleSubitem": "textsubitem 19.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 19.3, "titleSubitem": "textsubitem 19.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 19.4, "titleSubitem": "textsubitem 19.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 19.5, "titleSubitem": "textsubitem 19.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 19.1, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 19.2, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 19.3, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 19.4, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 19.5, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 20,
-          "titleItem": "item 20",
+          "titleItem": "item",
+          "icon": "airplane",
           "arraySubitem": [
-            {"idSubitem": 20.1, "titleSubitem": "textsubitem 20.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 20.2, "titleSubitem": "textsubitem 20.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 20.3, "titleSubitem": "textsubitem 20.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 20.4, "titleSubitem": "textsubitem 20.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 20.5, "titleSubitem": "textsubitem 20.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 20.1, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 20.2, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 20.3, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 20.4, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 20.5, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         }
       ]
@@ -245,62 +265,69 @@
       "arrayItem": [
         {
           "idItem": 21,
-          "titleItem": "item 21",
+          "titleItem": "item",
+          "icon": "youtube-logo",
           "arraySubitem": [
-            {"idSubitem": 21.1, "titleSubitem": "textsubitem 21.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 21.2, "titleSubitem": "textsubitem 21.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 21.3, "titleSubitem": "textsubitem 21.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 21.4, "titleSubitem": "textsubitem 21.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 21.5, "titleSubitem": "textsubitem 21.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 21.1, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 21.2, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 21.3, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 21.4, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 21.5, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 22,
-          "titleItem": "item 22",
+          "titleItem": "item",
+          "icon": "airplane-in-flight",
           "arraySubitem": [
-            {"idSubitem": 22.1, "titleSubitem": "textsubitem 22.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 22.2, "titleSubitem": "textsubitem 22.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 22.3, "titleSubitem": "textsubitem 22.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 22.4, "titleSubitem": "textsubitem 22.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 22.5, "titleSubitem": "textsubitem 22.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 22.1, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 22.2, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 22.3, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 22.4, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 22.5, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 23,
-          "titleItem": "item 23",
+          "titleItem": "item",
+          "icon": "function",
           "arraySubitem": [
-            {"idSubitem": 23.1, "titleSubitem": "textsubitem 23.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 23.2, "titleSubitem": "textsubitem 23.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 23.3, "titleSubitem": "textsubitem 23.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 23.4, "titleSubitem": "textsubitem 23.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 23.5, "titleSubitem": "textsubitem 23.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 23.1, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 23.2, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 23.3, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 23.4, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 23.5, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 24,
-          "titleItem": "item 24",
+          "titleItem": "item",
+          "icon": "airplane-landing",
           "arraySubitem": [
-            {"idSubitem": 24.1, "titleSubitem": "textsubitem 24.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 24.2, "titleSubitem": "textsubitem 24.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 24.3, "titleSubitem": "textsubitem 24.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 24.4, "titleSubitem": "textsubitem 24.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 24.5, "titleSubitem": "textsubitem 24.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 24.1, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 24.2, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 24.3, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 24.4, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 24.5, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 25,
-          "titleItem": "item 25",
+          "titleItem": "item",
+          "icon": "address-book",
           "arraySubitem": [
-            {"idSubitem": 25.1, "titleSubitem": "textsubitem 25.1", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 25.2, "titleSubitem": "textsubitem 25.2", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 25.3, "titleSubitem": "textsubitem 25.3", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 25.4, "titleSubitem": "textsubitem 25.4", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 25.5, "titleSubitem": "textsubitem 25.5", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 25.1, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 25.2, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 25.3, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 25.4, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 25.5, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         }
       ]
     }
   ],
   "sideBarVerticalisExpanded": true,
-  "sideBarVerticalSizeExpanded": 100
+  "sideBarVerticalSizeExpanded": 280,
+  "sideBarVerticalSizeCollapsed": 100,
+  "typeSidebar": "Vertical"
 }


### PR DESCRIPTION
This commit introduces several enhancements to the sidebar data structure and updates the documentation accordingly.

Changes to `sidebar.json`:
- Adds `sideBarVerticalSizeCollapsed` and `typeSidebar` properties.
- Updates `sideBarVerticalSizeExpanded` to 280.
- Adds an `icon` property to every item and sub-item, populated with Phosphor icons.
- Standardizes all `titleItem` and `titleSubitem` values to "item" and "subitem" respectively.

Changes to `sidebar/Descricao.md`:
- Updates the documentation to reflect all the new and modified keys in the JSON structure.