### PR TITLE
fix: Adjust icon format and update documentation

### DIFF
--- a/sidebar/Readme_Sidebar.md
+++ b/sidebar/Readme_Sidebar.md
@@ -27,7 +27,7 @@ Cada objeto dentro deste array representa um item de navegação principal, que 
 -   **Objeto de Item**:
 -   `idItem`: (Number) Um identificador numérico único para o item.
 -   `titleItem`: (String) O texto que será exibido para este item (atualmente padronizado como "item").
--   `icon`: (String) O nome de um ícone da biblioteca Phosphor Icons a ser exibido ao lado do título.
+-   `icon`: (String) O caminho do ícone no formato `phosphor-regular/nome-do-icone` para ser exibido ao lado do título.
     -   `arraySubitem`: (Array) Contém os subitens de navegação associados a este item principal.
 
 ## Estrutura do `arraySubitem`
@@ -37,7 +37,7 @@ Cada objeto neste array representa um subitem de navegação, que é o link fina
 -   **Objeto de Subitem**:
 -   `idSubitem`: (Number) Um identificador numérico único para o subitem, geralmente no formato `[idItem].[index]`.
 -   `titleSubitem`: (String) O texto que será exibido para o subitem (atualmente padronizado como "subitem").
--   `icon`: (String) O nome de um ícone da biblioteca Phosphor Icons a ser exibido ao lado do título.
+-   `icon`: (String) O caminho do ícone no formato `phosphor-regular/nome-do-icone` para ser exibido ao lado do título.
     -   `objectSubitem`: (Object) Um objeto que contém metadados e configurações para o comportamento do link do subitem.
         -   `type`: (String) Tipo de ação ou link.
         -   `pageid`: (String) Identificador da página de destino.
@@ -45,3 +45,7 @@ Cada objeto neste array representa um subitem de navegação, que é o link fina
         -   `targetBlank`: (Boolean) Define se o link deve ser aberto em uma nova aba (`true`) ou não (`false`).
         -   `loadProgress`: (Boolean) Indica se uma barra de progresso de carregamento deve ser exibida.
         -   `loadprogressColors`: (String/null) Cores para a barra de progresso.
+
+## Contexto de Front-end
+
+Esta estrutura de dados foi projetada para ser consumida por um front-end construído com a plataforma Weweb. A plataforma utiliza essa fonte de dados para renderizar a sidebar dinamicamente.

--- a/sidebar/sidebar.json
+++ b/sidebar/sidebar.json
@@ -6,61 +6,61 @@
         {
           "idItem": 1,
           "titleItem": "item",
-          "icon": "function",
+          "icon": "phosphor-regular/function",
           "arraySubitem": [
-            {"idSubitem": 1.1, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 1.2, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 1.3, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 1.4, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 1.5, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 1.1, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 1.2, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 1.3, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 1.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 1.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 2,
           "titleItem": "item",
-          "icon": "airplane-landing",
+          "icon": "phosphor-regular/airplane-landing",
           "arraySubitem": [
-            {"idSubitem": 2.1, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 2.2, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 2.3, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 2.4, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 2.5, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 2.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 2.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 2.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 2.4, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 2.5, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 3,
           "titleItem": "item",
-          "icon": "address-book",
+          "icon": "phosphor-regular/address-book",
           "arraySubitem": [
-            {"idSubitem": 3.1, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 3.2, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 3.3, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 3.4, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 3.5, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 3.1, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 3.2, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 3.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 3.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 3.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 4,
           "titleItem": "item",
-          "icon": "airplane-takeoff",
+          "icon": "phosphor-regular/airplane-takeoff",
           "arraySubitem": [
-            {"idSubitem": 4.1, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 4.2, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 4.3, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 4.4, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 4.5, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 4.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 4.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 4.3, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 4.4, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 4.5, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 5,
           "titleItem": "item",
-          "icon": "air-traffic-control",
+          "icon": "phosphor-regular/air-traffic-control",
           "arraySubitem": [
-            {"idSubitem": 5.1, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 5.2, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 5.3, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 5.4, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 5.5, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 5.1, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 5.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 5.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 5.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 5.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         }
       ]
@@ -71,61 +71,61 @@
         {
           "idItem": 6,
           "titleItem": "item",
-          "icon": "airplane-tilt",
+          "icon": "phosphor-regular/airplane-tilt",
           "arraySubitem": [
-            {"idSubitem": 6.1, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 6.2, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 6.3, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 6.4, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 6.5, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 6.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 6.2, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 6.3, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 6.4, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 6.5, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 7,
           "titleItem": "item",
-          "icon": "buildings",
+          "icon": "phosphor-regular/buildings",
           "arraySubitem": [
-            {"idSubitem": 7.1, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 7.2, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 7.3, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 7.4, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 7.5, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 7.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 7.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 7.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 7.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 7.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 8,
           "titleItem": "item",
-          "icon": "airplay",
+          "icon": "phosphor-regular/airplay",
           "arraySubitem": [
-            {"idSubitem": 8.1, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 8.2, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 8.3, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 8.4, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 8.5, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 8.1, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 8.2, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 8.3, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 8.4, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 8.5, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 9,
           "titleItem": "item",
-          "icon": "airplane",
+          "icon": "phosphor-regular/airplane",
           "arraySubitem": [
-            {"idSubitem": 9.1, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 9.2, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 9.3, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 9.4, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 9.5, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 9.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 9.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 9.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 9.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 9.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 10,
           "titleItem": "item",
-          "icon": "youtube-logo",
+          "icon": "phosphor-regular/youtube-logo",
           "arraySubitem": [
-            {"idSubitem": 10.1, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 10.2, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 10.3, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 10.4, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 10.5, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 10.1, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 10.2, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 10.3, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 10.4, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 10.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         }
       ]
@@ -136,61 +136,61 @@
         {
           "idItem": 11,
           "titleItem": "item",
-          "icon": "airplane-in-flight",
+          "icon": "phosphor-regular/airplane-in-flight",
           "arraySubitem": [
-            {"idSubitem": 11.1, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 11.2, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 11.3, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 11.4, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 11.5, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 11.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 11.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 11.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 11.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 11.5, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 12,
           "titleItem": "item",
-          "icon": "function",
+          "icon": "phosphor-regular/function",
           "arraySubitem": [
-            {"idSubitem": 12.1, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 12.2, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 12.3, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 12.4, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 12.5, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 12.1, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 12.2, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 12.3, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 12.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 12.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 13,
           "titleItem": "item",
-          "icon": "airplane-landing",
+          "icon": "phosphor-regular/airplane-landing",
           "arraySubitem": [
-            {"idSubitem": 13.1, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 13.2, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 13.3, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 13.4, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 13.5, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 13.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 13.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 13.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 13.4, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 13.5, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 14,
           "titleItem": "item",
-          "icon": "address-book",
+          "icon": "phosphor-regular/address-book",
           "arraySubitem": [
-            {"idSubitem": 14.1, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 14.2, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 14.3, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 14.4, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 14.5, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 14.1, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 14.2, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 14.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 14.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 14.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 15,
           "titleItem": "item",
-          "icon": "airplane-takeoff",
+          "icon": "phosphor-regular/airplane-takeoff",
           "arraySubitem": [
-            {"idSubitem": 15.1, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 15.2, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 15.3, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 15.4, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 15.5, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 15.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 15.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 15.3, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 15.4, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 15.5, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         }
       ]
@@ -201,61 +201,61 @@
         {
           "idItem": 16,
           "titleItem": "item",
-          "icon": "air-traffic-control",
+          "icon": "phosphor-regular/air-traffic-control",
           "arraySubitem": [
-            {"idSubitem": 16.1, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 16.2, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 16.3, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 16.4, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 16.5, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 16.1, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 16.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 16.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 16.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 16.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 17,
           "titleItem": "item",
-          "icon": "airplane-tilt",
+          "icon": "phosphor-regular/airplane-tilt",
           "arraySubitem": [
-            {"idSubitem": 17.1, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 17.2, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 17.3, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 17.4, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 17.5, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 17.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 17.2, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 17.3, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 17.4, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 17.5, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 18,
           "titleItem": "item",
-          "icon": "buildings",
+          "icon": "phosphor-regular/buildings",
           "arraySubitem": [
-            {"idSubitem": 18.1, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 18.2, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 18.3, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 18.4, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 18.5, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 18.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 18.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 18.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 18.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 18.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 19,
           "titleItem": "item",
-          "icon": "airplay",
+          "icon": "phosphor-regular/airplay",
           "arraySubitem": [
-            {"idSubitem": 19.1, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 19.2, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 19.3, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 19.4, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 19.5, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 19.1, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 19.2, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 19.3, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 19.4, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 19.5, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 20,
           "titleItem": "item",
-          "icon": "airplane",
+          "icon": "phosphor-regular/airplane",
           "arraySubitem": [
-            {"idSubitem": 20.1, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 20.2, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 20.3, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 20.4, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 20.5, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 20.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 20.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 20.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 20.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 20.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         }
       ]
@@ -266,61 +266,61 @@
         {
           "idItem": 21,
           "titleItem": "item",
-          "icon": "youtube-logo",
+          "icon": "phosphor-regular/youtube-logo",
           "arraySubitem": [
-            {"idSubitem": 21.1, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 21.2, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 21.3, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 21.4, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 21.5, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 21.1, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 21.2, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 21.3, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 21.4, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 21.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 22,
           "titleItem": "item",
-          "icon": "airplane-in-flight",
+          "icon": "phosphor-regular/airplane-in-flight",
           "arraySubitem": [
-            {"idSubitem": 22.1, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 22.2, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 22.3, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 22.4, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 22.5, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 22.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 22.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 22.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 22.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 22.5, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 23,
           "titleItem": "item",
-          "icon": "function",
+          "icon": "phosphor-regular/function",
           "arraySubitem": [
-            {"idSubitem": 23.1, "titleSubitem": "subitem", "icon": "address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 23.2, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 23.3, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 23.4, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 23.5, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 23.1, "titleSubitem": "subitem", "icon": "phosphor-regular/address-book", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 23.2, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 23.3, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 23.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 23.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 24,
           "titleItem": "item",
-          "icon": "airplane-landing",
+          "icon": "phosphor-regular/airplane-landing",
           "arraySubitem": [
-            {"idSubitem": 24.1, "titleSubitem": "subitem", "icon": "airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 24.2, "titleSubitem": "subitem", "icon": "airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 24.3, "titleSubitem": "subitem", "icon": "airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 24.4, "titleSubitem": "subitem", "icon": "youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 24.5, "titleSubitem": "subitem", "icon": "function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 24.1, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-takeoff", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 24.2, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-tilt", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 24.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplay", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 24.4, "titleSubitem": "subitem", "icon": "phosphor-regular/youtube-logo", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 24.5, "titleSubitem": "subitem", "icon": "phosphor-regular/function", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         },
         {
           "idItem": 25,
           "titleItem": "item",
-          "icon": "address-book",
+          "icon": "phosphor-regular/address-book",
           "arraySubitem": [
-            {"idSubitem": 25.1, "titleSubitem": "subitem", "icon": "air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 25.2, "titleSubitem": "subitem", "icon": "buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 25.3, "titleSubitem": "subitem", "icon": "airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 25.4, "titleSubitem": "subitem", "icon": "airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
-            {"idSubitem": 25.5, "titleSubitem": "subitem", "icon": "airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
+            {"idSubitem": 25.1, "titleSubitem": "subitem", "icon": "phosphor-regular/air-traffic-control", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 25.2, "titleSubitem": "subitem", "icon": "phosphor-regular/buildings", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 25.3, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 25.4, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-in-flight", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}},
+            {"idSubitem": 25.5, "titleSubitem": "subitem", "icon": "phosphor-regular/airplane-landing", "objectSubitem": {"type": "", "pageid": "", "sectionid": null, "targetBlank": false, "loadProgress": true, "loadprogressColors": null}}
           ]
         }
       ]


### PR DESCRIPTION
This commit applies final adjustments based on front-end requirements and updates the documentation accordingly.

Changes to `sidebar.json`:
- All icon values are now prefixed with `phosphor-regular/` to match the required format for the Weweb front-end.

Changes to documentation:
- The documentation file has been renamed from `Descricao.md` to `Readme_Sidebar.md`.
- The content has been updated to reflect the new icon format.
- A new section has been added to mention that the front-end is built with Weweb.